### PR TITLE
Use mrb_int instead of int.

### DIFF
--- a/src/mruby-tinyxml2.cpp
+++ b/src/mruby-tinyxml2.cpp
@@ -455,7 +455,7 @@ static mrb_value
 xml_document_parse(mrb_state *mrb, mrb_value self)
 {
   char *xml;
-  int len = 0;
+  mrb_int len = 0;
   XMLDocument *doc = static_cast<XMLDocument*>(DATA_PTR(self));
   mrb_get_args(mrb, "s", &xml, &len);
   XMLError error = doc->Parse(xml, static_cast<size_t>(len));


### PR DESCRIPTION
This change fixes my memory corruption problem.
mrb_get_args() with "s" expects mrb_int. See https://github.com/mruby/mruby/blob/master/src/class.c#L1110